### PR TITLE
Add bias gelu fused op

### DIFF
--- a/csrc/bias_gelu/bias_gelu.cu
+++ b/csrc/bias_gelu/bias_gelu.cu
@@ -1,0 +1,159 @@
+#include <ATen/ATen.h>
+#include <ATen/CUDAGeneratorImpl.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+#include <c10/cuda/CUDAMathCompat.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_profiler_api.h>
+#include "THC/THC.h"
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+#include <math.h>
+
+#define CELL(a, b) (((a) + (b) - 1) / (b))
+#if __cplusplus >= 201703L
+    #define IF_CONSTEXPR constexpr
+#else
+    #define IF_CONSTEXPR
+#endif
+
+template <typename acc_t>
+__device__ acc_t torch_gelu(acc_t y) {
+    return normcdff(y) * y;
+}
+
+template <typename acc_t>
+__device__ acc_t tanh_gelu(acc_t y) {
+    return y * 0.5 * (1.0 + tanhf(0.79788456 * y * (1 + 0.044715 * y * y)));
+}
+
+template <typename acc_t>
+__device__ acc_t torch_gelu_back(acc_t y, acc_t g) {
+    constexpr acc_t kBeta = M_2_SQRTPI * M_SQRT1_2 * 0.5;
+    acc_t cdf = normcdff(y);
+    acc_t pdf = expf(-0.5f * y * y) * kBeta;
+    return g * (cdf + y * pdf);
+}
+
+template <typename acc_t>
+__device__ acc_t tanh_gelu_back(acc_t y, acc_t g) {
+    acc_t tanh_out = tanhf(0.79788456 * y * (1 + 0.044715 * y * y));
+    acc_t ff = 0.5 * y * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * y * y)) + 0.5 * (1 + tanh_out);
+    return ff * g;
+}
+
+template <typename index_t, typename input_t, typename output_t, typename acc_t, acc_t (*gelu_func)(acc_t)>
+__global__ void bias_gelu_forward(output_t *dst, const input_t *src, const input_t *bias, index_t bsz, int dim) {
+    for (int j = threadIdx.x; j < dim; j += blockDim.x) {
+        if (blockIdx.x < bsz) {
+            index_t idx = blockIdx.x * dim + j;
+            acc_t y = (acc_t)(src[idx] + bias[j]);
+            dst[idx] = (output_t)gelu_func(y);
+        }
+    }
+}
+
+template <typename index_t, typename input_t, typename output_t, typename acc_t, acc_t (*gelu_back_func)(acc_t, acc_t)>
+__global__ void bias_gelu_backward(output_t *dst, const input_t *src, const input_t *bias,
+    const input_t *grad, index_t bsz, int dim) {
+    for (int j = threadIdx.x; j < dim; j += blockDim.x) {
+        if (blockIdx.x < bsz) {
+            index_t idx = blockIdx.x * dim + j;
+            acc_t y = (acc_t)(src[idx] + bias[j]);
+            acc_t g = grad[idx];
+            dst[idx] = (output_t)gelu_back_func(y, g);
+        }
+    }
+}
+
+template <float (*gelu_func)(float)>
+torch::Tensor bias_gelu_forward_cuda(const torch::Tensor &x, const torch::Tensor &bias) {
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    auto sizes = x.sizes();
+    size_t bsz = 1;
+    for (size_t i = 0; i + 1 < sizes.size(); ++i) {
+        bsz *= sizes[i];
+    }
+    int dim = sizes[sizes.size() - 1];
+    auto dst_options = x.options().requires_grad(false);
+    torch::Tensor results = torch::empty(sizes, dst_options);
+    auto type = x.scalar_type();
+    const int ThreadsPerBlock = 256;
+    if (type == at::ScalarType::BFloat16) {
+        bias_gelu_forward<size_t, nv_bfloat16, nv_bfloat16, float, gelu_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (nv_bfloat16 *)results.data_ptr(),
+            (const nv_bfloat16 *)x.data_ptr(),
+            (const nv_bfloat16 *)bias.data_ptr(),
+            bsz,
+            dim);
+    } else if (type == at::ScalarType::Half) {
+        bias_gelu_forward<size_t, half, half, float, gelu_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (half *)results.data_ptr(),
+            (const half *)x.data_ptr(),
+            (const half *)bias.data_ptr(),
+            bsz,
+            dim);
+    } else if (type == at::ScalarType::Float) {
+        bias_gelu_forward<size_t, float, float, float, gelu_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (float *)results.data_ptr(),
+            (const float *)x.data_ptr(),
+            (const float *)bias.data_ptr(),
+            bsz,
+            dim);
+    }
+    return results;
+}
+
+template <float (*gelu_back_func)(float, float)>
+torch::Tensor bias_gelu_backward_cuda(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    auto sizes = x.sizes();
+    size_t bsz = 1;
+    for (size_t i = 0; i + 1 < sizes.size(); ++i) {
+        bsz *= sizes[i];
+    }
+    int dim = sizes[sizes.size() - 1];
+    auto dst_options = x.options().requires_grad(false);
+    torch::Tensor results = torch::empty(sizes, dst_options);
+    auto type = x.scalar_type();
+    const int ThreadsPerBlock = 256;
+    if (type == at::ScalarType::BFloat16) {
+        bias_gelu_backward<size_t, nv_bfloat16, nv_bfloat16, float, gelu_back_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (nv_bfloat16 *)results.data_ptr(),
+            (const nv_bfloat16 *)x.data_ptr(),
+            (const nv_bfloat16 *)bias.data_ptr(),
+            (const nv_bfloat16 *)grad.data_ptr(),
+            bsz,
+            dim);
+    } else if (type == at::ScalarType::Half) {
+        bias_gelu_backward<size_t, half, half, float, gelu_back_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (half *)results.data_ptr(),
+            (const half *)x.data_ptr(),
+            (const half *)bias.data_ptr(),
+            (const half *)grad.data_ptr(),
+            bsz,
+            dim);
+    } else if (type == at::ScalarType::Float) {
+        bias_gelu_backward<size_t, float, float, float, gelu_back_func><<<bsz, ThreadsPerBlock, 0, stream>>>(
+            (float *)results.data_ptr(),
+            (const float *)x.data_ptr(),
+            (const float *)bias.data_ptr(),
+            (const float *)grad.data_ptr(),
+            bsz,
+            dim);
+    }
+    return results;
+}
+
+using ForwardFunc = torch::Tensor (*)(const torch::Tensor &, const torch::Tensor &);
+
+ForwardFunc bias_gelu_torch_forward_cuda = bias_gelu_forward_cuda<torch_gelu>;
+ForwardFunc bias_gelu_tanh_forward_cuda = bias_gelu_forward_cuda<tanh_gelu>;
+
+using BackwardFunc = torch::Tensor (*)(const torch::Tensor &, const torch::Tensor &, const torch::Tensor &);
+
+BackwardFunc bias_gelu_torch_backward_cuda = bias_gelu_backward_cuda<torch_gelu_back>;
+BackwardFunc bias_gelu_tanh_backward_cuda = bias_gelu_backward_cuda<tanh_gelu_back>;

--- a/csrc/bias_gelu/bias_gelu.cu
+++ b/csrc/bias_gelu/bias_gelu.cu
@@ -26,7 +26,7 @@ __device__ acc_t torch_gelu(acc_t y) {
 }
 
 template <typename acc_t>
-__device__ acc_t tanh_gelu(acc_t y) {
+__device__ acc_t fast_gelu(acc_t y) {
     return y * 0.5 * (1.0 + tanhf(0.79788456 * y * (1 + 0.044715 * y * y)));
 }
 
@@ -39,7 +39,7 @@ __device__ acc_t torch_gelu_back(acc_t y, acc_t g) {
 }
 
 template <typename acc_t>
-__device__ acc_t tanh_gelu_back(acc_t y, acc_t g) {
+__device__ acc_t fast_gelu_back(acc_t y, acc_t g) {
     acc_t tanh_out = tanhf(0.79788456 * y * (1 + 0.044715 * y * y));
     acc_t ff = 0.5 * y * ((1 - tanh_out * tanh_out) * (0.79788456 + 0.1070322243 * y * y)) + 0.5 * (1 + tanh_out);
     return ff * g;
@@ -151,9 +151,9 @@ torch::Tensor bias_gelu_backward_cuda(const torch::Tensor &x, const torch::Tenso
 using ForwardFunc = torch::Tensor (*)(const torch::Tensor &, const torch::Tensor &);
 
 ForwardFunc bias_gelu_torch_forward_cuda = bias_gelu_forward_cuda<torch_gelu>;
-ForwardFunc bias_gelu_tanh_forward_cuda = bias_gelu_forward_cuda<tanh_gelu>;
+ForwardFunc bias_gelu_fast_forward_cuda = bias_gelu_forward_cuda<fast_gelu>;
 
 using BackwardFunc = torch::Tensor (*)(const torch::Tensor &, const torch::Tensor &, const torch::Tensor &);
 
 BackwardFunc bias_gelu_torch_backward_cuda = bias_gelu_backward_cuda<torch_gelu_back>;
-BackwardFunc bias_gelu_tanh_backward_cuda = bias_gelu_backward_cuda<tanh_gelu_back>;
+BackwardFunc bias_gelu_fast_backward_cuda = bias_gelu_backward_cuda<fast_gelu_back>;

--- a/csrc/bias_gelu/interface.cpp
+++ b/csrc/bias_gelu/interface.cpp
@@ -4,9 +4,9 @@
 #include <vector>
 
 extern torch::Tensor (*bias_gelu_torch_forward_cuda)(const torch::Tensor &x, const torch::Tensor &bias);
-extern torch::Tensor (*bias_gelu_tanh_forward_cuda)(const torch::Tensor &x, const torch::Tensor &bias);
+extern torch::Tensor (*bias_gelu_fast_forward_cuda)(const torch::Tensor &x, const torch::Tensor &bias);
 extern torch::Tensor (*bias_gelu_torch_backward_cuda)(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad);
-extern torch::Tensor (*bias_gelu_tanh_backward_cuda)(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad);
+extern torch::Tensor (*bias_gelu_fast_backward_cuda)(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad);
 
 torch::Tensor bias_gelu_torch_forward(const torch::Tensor &x, const torch::Tensor &bias) {
     AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
@@ -16,12 +16,12 @@ torch::Tensor bias_gelu_torch_forward(const torch::Tensor &x, const torch::Tenso
     return bias_gelu_torch_forward_cuda(x, bias);
 }
 
-torch::Tensor bias_gelu_tanh_forward(const torch::Tensor &x, const torch::Tensor &bias) {
+torch::Tensor bias_gelu_fast_forward(const torch::Tensor &x, const torch::Tensor &bias) {
     AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
     AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
     AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
     AT_ASSERTM(x.scalar_type() == bias.scalar_type(), "the types mismatch");
-    return bias_gelu_tanh_forward_cuda(x, bias);
+    return bias_gelu_fast_forward_cuda(x, bias);
 }
 
 torch::Tensor bias_gelu_torch_backward(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
@@ -32,17 +32,17 @@ torch::Tensor bias_gelu_torch_backward(const torch::Tensor &x, const torch::Tens
     return bias_gelu_torch_backward_cuda(x, bias, grad);
 }
 
-torch::Tensor bias_gelu_tanh_backward(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
+torch::Tensor bias_gelu_fast_backward(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
     AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
     AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
     AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
     AT_ASSERTM(x.scalar_type() == bias.scalar_type() && x.scalar_type() == grad.scalar_type(), "the types mismatch");
-    return bias_gelu_tanh_backward_cuda(x, bias, grad);
+    return bias_gelu_fast_backward_cuda(x, bias, grad);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("forward_torch", &bias_gelu_torch_forward, "bias gelu torch -- Forward.");
-    m.def("forward_tanh", &bias_gelu_tanh_forward, "bias gelu tanh -- Forward.");
+    m.def("forward_fast", &bias_gelu_fast_forward, "bias gelu fast -- Forward.");
     m.def("backward_torch", &bias_gelu_torch_backward, "bias gelu torch -- Backward.");
-    m.def("backward_tanh", &bias_gelu_tanh_backward, "bias gelu tanh -- Backward.");
+    m.def("backward_fast", &bias_gelu_fast_backward, "bias gelu fast -- Backward.");
 }

--- a/csrc/bias_gelu/interface.cpp
+++ b/csrc/bias_gelu/interface.cpp
@@ -1,0 +1,48 @@
+#include <torch/extension.h>
+#include <ATen/Generator.h>
+#include <ATen/CUDAGeneratorImpl.h>
+#include <vector>
+
+extern torch::Tensor (*bias_gelu_torch_forward_cuda)(const torch::Tensor &x, const torch::Tensor &bias);
+extern torch::Tensor (*bias_gelu_tanh_forward_cuda)(const torch::Tensor &x, const torch::Tensor &bias);
+extern torch::Tensor (*bias_gelu_torch_backward_cuda)(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad);
+extern torch::Tensor (*bias_gelu_tanh_backward_cuda)(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad);
+
+torch::Tensor bias_gelu_torch_forward(const torch::Tensor &x, const torch::Tensor &bias) {
+    AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
+    AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
+    AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
+    AT_ASSERTM(x.scalar_type() == bias.scalar_type(), "the types mismatch");
+    return bias_gelu_torch_forward_cuda(x, bias);
+}
+
+torch::Tensor bias_gelu_tanh_forward(const torch::Tensor &x, const torch::Tensor &bias) {
+    AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
+    AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
+    AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
+    AT_ASSERTM(x.scalar_type() == bias.scalar_type(), "the types mismatch");
+    return bias_gelu_tanh_forward_cuda(x, bias);
+}
+
+torch::Tensor bias_gelu_torch_backward(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
+    AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
+    AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
+    AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
+    AT_ASSERTM(x.scalar_type() == bias.scalar_type() && x.scalar_type() == grad.scalar_type(), "the types mismatch");
+    return bias_gelu_torch_backward_cuda(x, bias, grad);
+}
+
+torch::Tensor bias_gelu_tanh_backward(const torch::Tensor &x, const torch::Tensor &bias, const torch::Tensor &grad) {
+    AT_ASSERTM(x.is_contiguous(), "input must be contiguous");
+    AT_ASSERTM(bias.dim() == 1, "expected 1D tensor");
+    AT_ASSERTM(bias.size(-1) == x.size(-1), "the dimension of bias and the last dimension of the input should be the same");
+    AT_ASSERTM(x.scalar_type() == bias.scalar_type() && x.scalar_type() == grad.scalar_type(), "the types mismatch");
+    return bias_gelu_tanh_backward_cuda(x, bias, grad);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("forward_torch", &bias_gelu_torch_forward, "bias gelu torch -- Forward.");
+    m.def("forward_tanh", &bias_gelu_tanh_forward, "bias gelu tanh -- Forward.");
+    m.def("backward_torch", &bias_gelu_torch_backward, "bias gelu torch -- Backward.");
+    m.def("backward_tanh", &bias_gelu_tanh_backward, "bias gelu tanh -- Backward.");
+}

--- a/fused_ops/bias_gelu/__init__.py
+++ b/fused_ops/bias_gelu/__init__.py
@@ -1,0 +1,9 @@
+try:
+    import torch
+    import fused_bias_gelu_cuda
+    from .fused_bias_gelu import BiasTorchGeLUFunction, BiasTanhGeLUFunction
+    del torch
+    del fused_bias_gelu_cuda
+    del fused_bias_gelu
+except ImportError as err:
+    print("cannot import kernels, please install the package")

--- a/fused_ops/bias_gelu/fused_bias_gelu.py
+++ b/fused_ops/bias_gelu/fused_bias_gelu.py
@@ -25,16 +25,16 @@ class BiasTorchGeLUFunction(torch.autograd.Function):
             grad_input_bias = grad_input
         return grad_input, grad_input_bias
 
-class BiasTanhGeLUFunction(torch.autograd.Function):
+class BiasFastGeLUFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input, bias):
         ctx.save_for_backward(input, bias)
-        return fused_bias_gelu_cuda.forward_tanh(input, bias)
+        return fused_bias_gelu_cuda.forward_fast(input, bias)
 
     @staticmethod
     def backward(ctx, grad_output):
         input, bias = ctx.saved_tensors
-        grad_input = fused_bias_gelu_cuda.backward_tanh(input, bias, grad_output)
+        grad_input = fused_bias_gelu_cuda.backward_fast(input, bias, grad_output)
         if len(grad_input.size()) > 1:
             sizes = grad_input.size()
             grad_input_bias = grad_input.view(-1, sizes[-1]).sum(dim=0)

--- a/fused_ops/bias_gelu/fused_bias_gelu.py
+++ b/fused_ops/bias_gelu/fused_bias_gelu.py
@@ -1,0 +1,43 @@
+import torch
+import fused_bias_gelu_cuda
+
+class BiasTorchGeLUFunction(torch.autograd.Function):
+    r"""Fused bias and GELU operator.
+    
+    Shape:
+        - Input: :math:`(*, D)`
+        - Bias: :math:`(D)`
+        - Output: :math:`(*, D)`
+    """
+    @staticmethod
+    def forward(ctx, input, bias):
+        ctx.save_for_backward(input, bias)
+        return fused_bias_gelu_cuda.forward_torch(input, bias)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, bias = ctx.saved_tensors
+        grad_input = fused_bias_gelu_cuda.backward_torch(input, bias, grad_output)
+        if len(grad_input.size()) > 1:
+            sizes = grad_input.size()
+            grad_input_bias = grad_input.view(-1, sizes[-1]).sum(dim=0)
+        else:
+            grad_input_bias = grad_input
+        return grad_input, grad_input_bias
+
+class BiasTanhGeLUFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, bias):
+        ctx.save_for_backward(input, bias)
+        return fused_bias_gelu_cuda.forward_tanh(input, bias)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, bias = ctx.saved_tensors
+        grad_input = fused_bias_gelu_cuda.backward_tanh(input, bias, grad_output)
+        if len(grad_input.size()) > 1:
+            sizes = grad_input.size()
+            grad_input_bias = grad_input.view(-1, sizes[-1]).sum(dim=0)
+        else:
+            grad_input_bias = grad_input
+        return grad_input, grad_input_bias

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,21 @@ ext_modules.append(
                                                 '--expt-relaxed-constexpr',
                                                 '--expt-extended-lambda'] + version_dependent_macros + generator_flag}))
 
+ext_modules.append(
+    CUDAExtension(name='fused_bias_gelu_cuda',
+                    sources=['csrc/bias_gelu/interface.cpp',
+                            'csrc/bias_gelu/bias_gelu.cu'],
+                    include_dirs=[os.path.join(this_dir, 'csrc')],
+                    extra_compile_args={'cxx': ['-O3',] + version_dependent_macros + generator_flag,
+                                                '-gencode', 'arch=compute_70,code=sm_70',
+                                                '-gencode', 'arch=compute_80,code=sm_80',
+                                                '-U__CUDA_NO_HALF_OPERATORS__',
+                                                '-U__CUDA_NO_BFLOAT16_OPERATORS__',
+                                                '-U__CUDA_NO_HALF_CONVERSIONS__',
+                                                '-U__CUDA_NO_BFLOAT16_CONVERSIONS__',
+                                                '--expt-relaxed-constexpr',
+                                                '--expt-extended-lambda'] + version_dependent_macros + generator_flag}))
+
 setup(
     name='fused_ops',
     version='0.1',


### PR DESCRIPTION
Add fused bias gelu operator with two implementations of [pytorch](https://github.com/pytorch/pytorch/blob/5fcf49f59696ca7394be638d788076b313a946d8/aten/src/ATen/native/cuda/Activation.cu) and [megatron](https://github.com/NVIDIA/Megatron-LM/blob/aed2f75e209e525c842aec7c044af7acae2a4614/megatron/model/fused_bias_gelu.py)